### PR TITLE
chore(oparl): updated todos

### DIFF
--- a/src/models/OParl/AgendaItem.test.ts
+++ b/src/models/OParl/AgendaItem.test.ts
@@ -2,7 +2,7 @@ import { AgendaItem, IAgendaItem } from './AgendaItem';
 
 const maximalInput: IAgendaItem = {
   externalId: 'eId',
-  type: 't', // TODO: add proper type
+  type: 't',
   name: 'n',
   auxiliaryFile: ['af1', 'af2', 'af3'],
   consultation: 'cons',
@@ -25,7 +25,7 @@ const maximalInput: IAgendaItem = {
 
 const minimalInput: IAgendaItem = {
   externalId: 'eId',
-  type: 't', // TODO: add proper type
+  type: 't',
 };
 
 describe('creating an AgendaItem', () => {

--- a/src/models/OParl/Body.test.ts
+++ b/src/models/OParl/Body.test.ts
@@ -2,7 +2,7 @@ import { Body, IBody } from './Body';
 
 const maximalInput: IBody = {
   externalId: 'eId',
-  type: 't', // TODO: add proper type
+  type: 't',
   name: 'n',
   organization: ['o1', 'o2'],
   person: ['pe'],
@@ -35,7 +35,7 @@ const maximalInput: IBody = {
 
 const minimalInput: IBody = {
   externalId: 'eId',
-  type: 't', // TODO: add proper type
+  type: 't',
   name: 'n',
   organization: ['o1', 'o2'],
   person: ['pe'],

--- a/src/models/OParl/Consultation.test.ts
+++ b/src/models/OParl/Consultation.test.ts
@@ -2,7 +2,7 @@ import { Consultation, IConsultation } from './Consultation';
 
 const maximalInput: IConsultation = {
   externalId: 'eId',
-  type: 't', // TODO: add proper type
+  type: 't',
   agendaItem: 'ai',
   authoritative: true,
   organization: ['o1', 'o2'],
@@ -19,7 +19,7 @@ const maximalInput: IConsultation = {
 
 const minimalInput: IConsultation = {
   externalId: 'eId',
-  type: 't', // TODO: add proper type
+  type: 't',
 };
 
 describe('creating a Consultation', () => {

--- a/src/models/OParl/File.test.ts
+++ b/src/models/OParl/File.test.ts
@@ -2,7 +2,7 @@ import { File, IFile } from './File';
 
 const maximalInput: IFile = {
   externalId: 'eId',
-  type: 't', // TODO: add proper type
+  type: 't',
   accessUrl: 'au',
   agendaItem: ['ai1', 'ai2'],
   date: new Date(),
@@ -30,7 +30,7 @@ const maximalInput: IFile = {
 
 const minimalInput: IFile = {
   externalId: 'eId',
-  type: 't', // TODO: add proper type
+  type: 't',
   accessUrl: 'au',
 };
 

--- a/src/models/OParl/LegislativeTerm.test.ts
+++ b/src/models/OParl/LegislativeTerm.test.ts
@@ -2,7 +2,7 @@ import { ILegislativeTerm, LegislativeTerm } from './LegislativeTerm';
 
 const maximalInput: ILegislativeTerm = {
   externalId: 'eId',
-  type: 't', // TODO: add proper type
+  type: 't',
   name: 'n',
   body: 'b',
   startDate: new Date(),
@@ -16,7 +16,7 @@ const maximalInput: ILegislativeTerm = {
 };
 const minimalInput: ILegislativeTerm = {
   externalId: 'eId',
-  type: 't', // TODO: add proper type
+  type: 't',
 };
 
 describe('creating a LegislativeTerm', () => {

--- a/src/models/OParl/Location.test.ts
+++ b/src/models/OParl/Location.test.ts
@@ -2,7 +2,7 @@ import { ILocation, Location } from './Location';
 
 const maximalInput: ILocation = {
   externalId: 'eId',
-  type: 't', // TODO: add proper type
+  type: 't',
   bodies: ['b1', 'b2', 'b3'],
   description: 'd',
   geojson: '{}',
@@ -25,7 +25,7 @@ const maximalInput: ILocation = {
 
 const minimalInput: ILocation = {
   externalId: 'eId',
-  type: 't', // TODO: add proper type
+  type: 't',
 };
 
 describe('creating a Location', () => {

--- a/src/models/OParl/Meeting.test.ts
+++ b/src/models/OParl/Meeting.test.ts
@@ -2,7 +2,7 @@ import { IMeeting, Meeting } from './Meeting';
 
 const maximalInput: IMeeting = {
   externalId: 'eId',
-  type: 't', // TODO: add proper type
+  type: 't',
   agendaItem: ['a1', 'a2'],
   auxiliaryFile: ['f1', 'f2'],
   cancelled: false,
@@ -26,7 +26,7 @@ const maximalInput: IMeeting = {
 
 const minimalInput: IMeeting = {
   externalId: 'eId',
-  type: 't', // TODO: add proper type
+  type: 't',
 };
 
 describe('creating a Meeting', () => {

--- a/src/models/OParl/Membership.test.ts
+++ b/src/models/OParl/Membership.test.ts
@@ -2,7 +2,7 @@ import { IMembership, Membership } from './Membership';
 
 const maximalInput: IMembership = {
   externalId: 'eId',
-  type: 't', // TODO: add proper type
+  type: 't',
   endDate: new Date(),
   onBehalfOf: 'obo',
   organization: 'o',
@@ -20,7 +20,7 @@ const maximalInput: IMembership = {
 
 const minimalInput: IMembership = {
   externalId: 'eId',
-  type: 't', // TODO: add proper type
+  type: 't',
 };
 
 describe('creating a Membership', () => {

--- a/src/models/OParl/OParlBase.ts
+++ b/src/models/OParl/OParlBase.ts
@@ -1,6 +1,6 @@
 export interface OParlBase {
   externalId: string;
-  type: string; // TODO: refine here?
+  type: string; // this needs to be refined once we add a more specific validation of the "type" entry in the models
   created?: Date;
   modified?: Date;
   license?: string;
@@ -12,7 +12,7 @@ export interface OParlBase {
 // always generate a new object to merge with using Object.assign
 export const oParlBaseSchema = () => ({
   externalId: { type: String, required: true },
-  type: { type: String, required: true },
+  type: { type: String, required: true }, // TODO: refine "type" for different models
   created: Date,
   modified: Date,
   license: String,

--- a/src/models/OParl/Organization.test.ts
+++ b/src/models/OParl/Organization.test.ts
@@ -2,7 +2,7 @@ import { IOrganization, Organization } from './Organization';
 
 const maximalInput: IOrganization = {
   externalId: 'eId',
-  type: 't', // TODO: add proper type
+  type: 't',
   body: 'b',
   classification: 'c',
   endDate: new Date(),
@@ -28,7 +28,7 @@ const maximalInput: IOrganization = {
 
 const minimalInput: IOrganization = {
   externalId: 'eId',
-  type: 't', // TODO: add proper type
+  type: 't',
 };
 
 describe('creating a Organization', () => {

--- a/src/models/OParl/Paper.test.ts
+++ b/src/models/OParl/Paper.test.ts
@@ -2,7 +2,7 @@ import { IPaper, Paper } from './Paper';
 
 const maximalInput: IPaper = {
   externalId: 'eId',
-  type: 't', // TODO: add proper type
+  type: 't',
   auxiliaryFile: ['a1', 'a2'],
   body: 'b',
   consultation: ['c1'],
@@ -28,7 +28,7 @@ const maximalInput: IPaper = {
 
 const minimalInput: IPaper = {
   externalId: 'eId',
-  type: 't', // TODO: add proper type
+  type: 't',
 };
 
 describe('creating a Paper', () => {

--- a/src/models/OParl/Person.test.ts
+++ b/src/models/OParl/Person.test.ts
@@ -2,7 +2,7 @@ import { IPerson, Person } from './Person';
 
 const maximalInput: IPerson = {
   externalId: 'eId',
-  type: 't', // TODO: add proper type
+  type: 't',
   affix: 'af',
   body: 'b1',
   email: ['em'],
@@ -28,7 +28,7 @@ const maximalInput: IPerson = {
 
 const minimalInput: IPerson = {
   externalId: 'eId',
-  type: 't', // TODO: add proper type
+  type: 't',
 };
 
 describe('creating a Person', () => {

--- a/src/models/OParl/System.test.ts
+++ b/src/models/OParl/System.test.ts
@@ -2,7 +2,7 @@ import { ISystem, System } from './System';
 
 const maximalInput: ISystem = {
   externalId: 'eId',
-  type: 't', // TODO: add proper type
+  type: 't',
   body: ['b1', 'b2'],
   oparlVersion: 'ov',
   contactEmail: 'ce',
@@ -22,7 +22,7 @@ const maximalInput: ISystem = {
 
 const minimalInput: ISystem = {
   externalId: 'eId',
-  type: 't', // TODO: add proper type,
+  type: 't',
   body: ['b'],
   oparlVersion: 'ov',
 };

--- a/src/parser/OParl/file.ts
+++ b/src/parser/OParl/file.ts
@@ -9,6 +9,7 @@ export const parseFile = (json) => {
   if (isObjectLike(json)) {
     const externalId = json.id; // change the id given to us to be the externalId instead
     delete json.id; // remove the id key from the json to ensure we do not preset it for mongo db
+
     return {
       ...json,
       externalId,

--- a/src/parser/parserHelpers.ts
+++ b/src/parser/parserHelpers.ts
@@ -1,12 +1,15 @@
 import { isArray } from 'lodash';
 
-// TODO: improve filter to only match proper ids?
 export const mapToIds = (json: unknown): string[] => {
   if (isArray(json)) {
     return json.map((value) => value?.id).filter((id) => id !== undefined);
   }
 
-  // TODO: add error log
+  console.warn(
+    'Invalid json passed to "mapToIds". The required input is an array. Got: ',
+    json,
+  );
+
   // return empty array as a fallback
   return [];
 };

--- a/src/resolvers/resolvers.ts
+++ b/src/resolvers/resolvers.ts
@@ -24,6 +24,7 @@ import {
 } from './roadwork';
 
 // TODO: extract the remaining resolvers
+// TODO: remove roadworks altogether, as it was a test/dummy model
 const baseResolvers = {
   Date: dateScalar,
   Query: {

--- a/src/services/OParl/importHelpers.ts
+++ b/src/services/OParl/importHelpers.ts
@@ -25,9 +25,8 @@ export const getJson = async (value: unknown) => {
 
 export const updateOrCreateEntry = async (
   json: Record<string, unknown>,
-  // TODO: improve type of parsers. for now ensure that this is at least a function
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  parseJson: (...args: any) => any,
+  parseJson: (json: Record<string, unknown>) => any,
   model: OParlModel,
   addToQueue?: [ImportQueueEntry | ImportQueueEntry[], ImportType][],
   queue?: ImportQueue,
@@ -53,11 +52,12 @@ export const updateOrCreateEntry = async (
     if (isArray(list[0])) {
       queue?.add(
         ...list[0].map(
-          (entry) => [entry, list[1]] as [ImportQueueEntry, ImportType],
+          (arrayEntry) =>
+            [arrayEntry, list[1]] as [ImportQueueEntry, ImportType],
         ),
       );
     }
   });
 
-  return await entry.save();
+  return entry.save();
 };

--- a/src/services/OParl/importer.ts
+++ b/src/services/OParl/importer.ts
@@ -1,5 +1,3 @@
-// TODO: define entry point through script
-
 import { isString } from 'lodash';
 
 import { UniqueQueue } from '../../UniqueQueue';
@@ -26,12 +24,11 @@ const preferFullEntry = (a: [ImportQueueEntry, ImportType]) => {
   return !isString(a[0]);
 };
 
+// add functionality for incremental updates here, once performance becomes an issue
 export const importOParl = async (
   entryUrl: string,
   entryType = ImportType.System,
 ) => {
-  // TODO: get last import date
-
   // use a queue that saves the importer function which should be used with the corresponding url
   const importQueue: ImportQueue = new UniqueQueue<
     [ImportQueueEntry, ImportType]
@@ -46,7 +43,6 @@ export const importOParl = async (
 
     next = importQueue.next();
   }
-  // TODO: set last import date
 
   return true;
 };

--- a/src/services/OParl/paginatedList.ts
+++ b/src/services/OParl/paginatedList.ts
@@ -6,7 +6,7 @@ import {
   formatCreatedUntil,
 } from '../../helpers';
 
-// TODO: improve importing of paginated lists -> import/update entries directly as they are already available
+// if performance becomes problematic: improve importing of paginated lists -> import/update entries directly as they are already available
 
 // fetch all entries and of a paginated list and extract the ids
 export const fetchPaginatedOParlList = async (


### PR DESCRIPTION
- removed todos where they are outdated or not helpful
  - replaced some with instructional comments
  - removed redundant todos, at places that will become apparent (due to type conflicts) once the underlying issue gets tackled
- added console.warn to the error case of mapToIds
- improved type of updateOrCreateEntry