### PR TITLE
chore(tests): create date from milliseconds

### DIFF
--- a/src/services/OParl/body.test.ts
+++ b/src/services/OParl/body.test.ts
@@ -24,8 +24,8 @@ describe('importing a body', () => {
     basicImportTest(
       importBody,
       testUrl,
-      new Date('2017-05-01'),
-      new Date('2017-05-31'),
+      new Date(1493596800000),
+      new Date(1496188800000),
     ),
   );
 
@@ -34,8 +34,8 @@ describe('importing a body', () => {
     basicImportTest(
       importBody,
       testUrl2,
-      new Date('2016-06-02'),
-      new Date('2016-07-31'),
+      new Date(1464825600000),
+      new Date(1469923200000),
     ),
   );
 

--- a/src/services/OParl/organization.test.ts
+++ b/src/services/OParl/organization.test.ts
@@ -21,8 +21,8 @@ describe('importing an organization', () => {
     basicImportTest(
       importOrganization,
       testUrl,
-      new Date('2017-06-01'),
-      new Date('2018-06-01'),
+      new Date(1496275200000),
+      new Date(1527811200000),
     ),
   );
 


### PR DESCRIPTION
- the tests in the ci of github failed due to timezone differences
  - i updated the tests to use millisecond timestamps instead